### PR TITLE
added support for streaming api

### DIFF
--- a/src/cosdata/api/client.py
+++ b/src/cosdata/api/client.py
@@ -4,6 +4,7 @@ import requests
 from typing import Optional, Dict, Any, List
 from .collections import Collection
 from .auth import Auth
+from .sync_transactions import SyncTransactions
 
 class Client:
     """
@@ -36,6 +37,9 @@ class Client:
         # Initialize authentication
         self.auth = Auth(username, password)
         self.auth.set_client_info(host, verify)
+        
+        # Initialize sync transactions module
+        self.sync_transactions = SyncTransactions(self)
         
         self._session = None
     

--- a/src/cosdata/api/collections.py
+++ b/src/cosdata/api/collections.py
@@ -1,7 +1,7 @@
 # collections.py
 import json
 import requests
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Union
 from contextlib import contextmanager
 from .indexes import Index
 from .search import Search
@@ -271,4 +271,18 @@ class Collection:
         Returns:
             Transaction object
         """
-        return Transaction(self) 
+        return Transaction(self)
+    
+    def stream_upsert(self, vectors: Union[Dict[str, Any], List[Dict[str, Any]]]) -> Dict[str, Any]:
+        """
+        Upsert vectors in this collection using streaming sync transaction.
+        Returns immediately with the result.
+        """
+        return self.client.sync_transactions.stream_upsert(self.name, vectors)
+
+    def stream_delete(self, vector_id: str) -> Dict[str, Any]:
+        """
+        Delete a vector from this collection using streaming sync transaction.
+        Returns immediately with the result.
+        """
+        return self.client.sync_transactions.stream_delete(self.name, vector_id) 

--- a/src/cosdata/api/sync_transactions.py
+++ b/src/cosdata/api/sync_transactions.py
@@ -1,0 +1,72 @@
+import json
+import requests
+from typing import Dict, Any, List, Union
+
+class SyncTransactions:
+    """
+    Synchronous transactions module for managing vector operations with immediate execution.
+    """
+    
+    def __init__(self, client):
+        """
+        Initialize the sync transactions module.
+        
+        Args:
+            client: Client instance
+        """
+        self.client = client
+    
+    def stream_upsert(self, collection_name: str, vectors: Union[Dict[str, Any], List[Dict[str, Any]]]) -> Dict[str, Any]:
+        """
+        Upsert vectors in a collection using streaming sync transaction.
+        Returns immediately with the result.
+        
+        Args:
+            collection_name: Name of the collection
+            vectors: Single vector dict or list of vector dicts to upsert
+            
+        Returns:
+            Response data from the upsert operation
+        """
+        # Ensure vectors is a list
+        if isinstance(vectors, dict):
+            vectors = [vectors]
+        
+        url = f"{self.client.base_url}/collections/{collection_name}/streaming/upsert"
+        data = {"vectors": vectors}
+        
+        response = requests.post(
+            url,
+            headers=self.client._get_headers(),
+            data=json.dumps(data),
+            verify=self.client.verify_ssl
+        )
+        
+        if response.status_code not in [200, 201, 204]:
+            raise Exception(f"Failed to streaming upsert vectors: {response.text}")
+        
+        return response.json() if response.content else {}
+    
+    def stream_delete(self, collection_name: str, vector_id: str) -> Dict[str, Any]:
+        """
+        Delete a vector from a collection using streaming sync transaction.
+        Returns immediately with the result.
+        
+        Args:
+            collection_name: Name of the collection
+            vector_id: ID of the vector to delete (single only)
+            
+        Returns:
+            Response data from the delete operation
+        """
+        url = f"{self.client.base_url}/collections/{collection_name}/streaming/vectors/{vector_id}"
+        response = requests.delete(
+            url,
+            headers=self.client._get_headers(),
+            verify=self.client.verify_ssl
+        )
+        
+        if response.status_code not in [200, 201, 204]:
+            raise Exception(f"Failed to streaming delete vector: {response.text}")
+        
+        return response.json() if response.content else {}

--- a/test-simple-sync.py
+++ b/test-simple-sync.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Test script for simple sync transaction methods.
+"""
+
+import logging
+import sys
+import os
+
+# Add the src directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from cosdata import Client
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def test_simple_sync_methods():
+    """Test simple sync transaction methods."""
+    
+    # Initialize client
+    client = Client(
+        host="http://127.0.0.1:8443",
+        username="admin",
+        password="asdfg",
+        verify=False
+    )
+    
+    collection_name = "test_simple_sync"
+    
+    try:
+        # Create collection
+        logger.info(f"Creating collection: {collection_name}")
+        collection = client.create_collection(
+            name=collection_name,
+            dimension=5,  # Small dimension for testing
+            description="Test collection for simple sync methods"
+        )
+        
+        # Test 1: Single vector sync_upsert
+        logger.info("Test 1: Single vector sync_upsert")
+        vector1 = {
+            "id": "vector-1",
+            "document_id": "doc-123",
+            "dense_values": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "metadata": {
+                "category": "technology",
+                "tags": "ai,machine-learning",
+                "score": 95
+            },
+            "text": "Sample text content"
+        }
+        
+        result = collection.stream_upsert(vector1)
+        logger.info(f"Single vector upsert result: {result}")
+        # result = collection.stream_delete(vector1["id"])
+        # logger.info(f"Single vector delete result: {result}")
+        print(f"--------------------------------")
+        
+        # Test 2: Multiple vectors stream_upsert
+        logger.info("Test 2: Multiple vectors stream_upsert")
+        vectors = [
+            {
+                "id": "vector-2",
+                "document_id": "doc-124",
+                "dense_values": [0.2, 0.3, 0.4, 0.5, 0.6],
+                "metadata": {
+                    "category": "science",
+                    "tags": "research,data",
+                    "score": 89
+                },
+                "text": "Another sample text"
+            },
+            {
+                "id": "vector-3",
+                "document_id": "doc-125",
+                "dense_values": [0.3, 0.4, 0.5, 0.6, 0.7],
+                "metadata": {
+                    "category": "education",
+                    "tags": "learning,tutorial",
+                    "score": 92
+                },
+                "text": "Third sample text"
+            }
+        ]
+        
+        result = collection.stream_upsert(vectors)
+        logger.info(f"Multiple vectors upsert result: {result}")
+        
+        logger.info("All simple sync method tests completed successfully!")
+        
+    except Exception as e:
+        logger.error(f"Error during simple sync method tests: {e}")
+        raise
+    finally:
+        # Clean up - delete the collection
+        try:
+            logger.info(f"Cleaning up - deleting collection: {collection_name}")
+            collection.delete()
+        except Exception as e:
+            logger.warning(f"Failed to delete collection: {e}")
+
+if __name__ == "__main__":
+    test_simple_sync_methods() 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 2
+requires-python = ">=3.8"
+
+[[package]]
+name = "cosdata-client"
+version = "0.2.2"
+source = { editable = "." }


### PR DESCRIPTION
# Added stream_upsert and stream_delete methods to the SDK.
- `stream_upsert`: Upserts one or more vectors via `POST /collections/{collection_id}/streaming/upsert`.
 - `stream_delete`: Deletes a single vector via `DELETE /collections/{collection_id}/streaming/vectors/{vector_id}`.
 
Both methods are available on the Collection object.
Updated tests to cover both single and multiple vector streaming upserts.

@tinkn please review